### PR TITLE
Remove redundant npm dependency metadata for react and react-dom

### DIFF
--- a/src/Feliz.Plotly/Feliz.Plotly.fsproj
+++ b/src/Feliz.Plotly/Feliz.Plotly.fsproj
@@ -24,8 +24,6 @@
   
   <PropertyGroup>
     <NpmDependencies>
-      <NpmPackage Name="react" Version="&gt;= 16.8.0" ResolutionStrategy="max"/>
-      <NpmPackage Name="react-dom" Version="&gt;= 16.8.0" ResolutionStrategy="max"/>
       <NpmPackage Name="plotly.js" Version="gte 1.5 lt 2" ResolutionStrategy="max" />
       <NpmPackage Name="react-plotly.js" Version="gte 2.3 lt 3" ResolutionStrategy="max" />
     </NpmDependencies>


### PR DESCRIPTION
The npm dependencies for `react` and `react-dom` are redundant because `Feliz` already requires them from the project file. So when Femto installs `Feliz.Plotly` then `react` and `react-dom` are installed as well along-side with them. 

Is there a specific reason why you included these dependencies here?