### PR TITLE
Add the link of the documentation into README

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@ Fable bindings for [plotly.js](https://github.com/plotly/plotly.js) with [Feliz]
 
 Lets you build visualizations in an easy, discoverable, and safe fashion.
 
+See the full documentation with live examples: [https://shmew.github.io/Feliz.Plotly](https://shmew.github.io/Feliz.Plotly/)
+
 A quick look:
 
 ```fs


### PR DESCRIPTION
Because I want to link to `Feliz.Plotly` from the documentation of `Feliz` which makes the documentation link available from there as well 