### PR TITLE
Possible fix for tickfont

### DIFF
--- a/docs/Plotly/Examples/Bar/ColoredAndStyled.fs
+++ b/docs/Plotly/Examples/Bar/ColoredAndStyled.fs
@@ -49,10 +49,11 @@ let chart () =
                         title.font.size 16
                         title.font.color (colors.rgb(107, 107, 107))
                     ]
-                    //yaxis.tickfont [  // Having trouble resolving the namespace
-                    //    tickfont.size 16
-                    //    tickfont.color (colors.rgb(107, 107, 107))
-                    //]
+                ]
+                 
+                layout.yaxis.tickfont [ 
+                    yaxis.tickfont.size 16
+                    yaxis.tickfont.color (colors.rgb(107, 107, 107))
                 ]
             ]
             layout.legend [


### PR DESCRIPTION
Maybe this fixes the problem for #8? The tick font was not used in the right place. I like the API so far of the library but I can see where the users will get confused when abbreviating these module/type names and having the types not being resolved in the right place. Again I think the builder syntax will work best here

BTW, great work on adding so many examples, really awesome! 